### PR TITLE
Removed link parameter on adwords_campaigns_core.name

### DIFF
--- a/adwords_campaigns_core.view.lkml
+++ b/adwords_campaigns_core.view.lkml
@@ -36,11 +36,6 @@ view: adwords_campaigns_core {
   dimension: name {
     type: string
     sql: ${TABLE}.name ;;
-    link: {
-      label: "Campaign Lookup Dashboard"
-      icon_url: "https://looker.com/favicon.ico"
-      url: "https://boomerang.looker.com/dashboards/6?Campaign%20Name={{ value }}"
-    }
   }
 
   dimension_group: received {


### PR DESCRIPTION
Link to https://boomerang.looker.com/dashboards/6?Campaign%20Name={{ value }} was showing up despite overriding the dimension in the config project. 